### PR TITLE
Load (fetch) collection before passing it to the view

### DIFF
--- a/src/app/advancedCollection.js
+++ b/src/app/advancedCollection.js
@@ -1,0 +1,20 @@
+import Bn from 'backbone'
+
+/**
+ * Overrides fetch method from Backbone so we can use collection out of the box with promises.
+ * All standard fetch return properties are still there for developer to use if necessary.
+ */
+export default Bn.Collection.extend({
+
+  fetch(options) {
+      return Bn.Collection.prototype.fetch.call(this, options)
+      .then((data, textStatus, jqXHR) => {
+          let collection = new Bn.Collection(data);
+          return new Promise(function (resolve, reject) {
+              resolve({collection, data, textStatus, jqXHR})
+          })
+      });
+
+  }
+
+})

--- a/src/app/posts/collection.js
+++ b/src/app/posts/collection.js
@@ -1,6 +1,6 @@
-import Bn from 'backbone'
+import RentlioCollection from '../advancedCollection'
 
-export default Bn.Collection.extend({
+export default RentlioCollection.extend({
     
     url: 'https://jsonplaceholder.typicode.com/posts'
     

--- a/src/app/posts/collection.js
+++ b/src/app/posts/collection.js
@@ -1,6 +1,6 @@
-import RentlioCollection from '../advancedCollection'
+import AdvancedCollection from '../advancedCollection'
 
-export default RentlioCollection.extend({
+export default AdvancedCollection.extend({
     
     url: 'https://jsonplaceholder.typicode.com/posts'
     

--- a/src/app/posts/view.js
+++ b/src/app/posts/view.js
@@ -1,21 +1,14 @@
 import Mn from 'backbone.marionette'
 import Template from './template.hbs'
-import Collection from './collection'
 
 export default Mn.View.extend({
     
     template: Template,
-    
-    initialize() {
-        this.collection = new Collection()
-        this.collection.on('sync', this.render)
-        this.collection.fetch()
-    },
-    
+
     serializeData() {
         return {
             posts: this.collection.models
         }
     }
-    
+
 })

--- a/src/app/root/view.js
+++ b/src/app/root/view.js
@@ -2,6 +2,7 @@ import Mn from 'backbone.marionette'
 import template from './template.hbs'
 import UsersView from '../users/view'
 import PostsView from '../posts/view'
+import Collection from '../posts/collection'
 
 export default Mn.View.extend({
     
@@ -16,7 +17,12 @@ export default Mn.View.extend({
     },
     
     showPosts() {
-        this.getRegion('content').show(new PostsView())
+        new Collection().fetch().then(resp =>
+            this.getRegion('content')
+            .show(new PostsView({
+                collection: resp.collection
+            }))
+        )
     }
     
 })

--- a/tests/posts/view.test.js
+++ b/tests/posts/view.test.js
@@ -1,0 +1,43 @@
+import chai from 'chai'
+import PostsView from '../../src/app/posts/view'
+
+const expect = chai.expect
+let view
+
+describe('PostsView', () => {
+
+    beforeEach('instantiate posts view', () => {
+        let collection = new Backbone.Collection()
+        view = new PostsView({collection: collection})
+    })
+
+    it('should have properties', () => {
+        expect(view.template).to.exist
+        expect(view.collection).to.exist
+    })
+
+    it('should have methods', () => {
+        expect(view.serializeData).to.be.a('function')
+    })
+
+    it('should serialize data', () => {
+        const data = view.serializeData()
+        expect(data.posts).to.exist
+        expect(data.posts).to.be.an('array')
+    })
+
+    it('should render header', () => {
+        view.render()
+        expect(view.$el.find('h2').text()).to.equal('Posts')
+    })
+
+    describe('after render', () => {
+        it('should contain collection data', () => {
+            view.collection.add({title: 'Post 1', body: "Message body from post 1"})
+            view.render()
+            expect(view.$el.find('h3').text()).to.equal(view.collection.models[0].get('title'))
+            expect(view.$el.find('p').text()).to.equal(view.collection.models[0].get('body'))
+        })
+    })
+
+})


### PR DESCRIPTION
Best practice suggests that view already has a collection prepared for rendering and not to fetch it somewhere inside the view.
I see two problems with the current solution
1. Marionette onRender method is being called twice (first when this.getRegion('region').show(...) is executed and then again on 'sync' inside the view#initialize), causing the view to render things twice
2. It is easier to test the collection data inside the view because collection is not instantiated inside the #initialize method.

* Changes implemented only for posts part of the app
* There is new advancedCollection.js file which overrides fetch method from collection so we can use collection in promises (otherwise we get only jQuery raw data)
* tests/posts/view.test.js can now easily test data from collection